### PR TITLE
Add cancelled field to events

### DIFF
--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -95,8 +95,12 @@
       ]
     },
     "volatile": {
-        "description": "If true event may not take place",
-        "type": "boolean"
+      "description": "If true event may not take place",
+      "type": "boolean"
+    },
+    "cancelled": {
+      "description": "If true, the event was cancelled",
+      "type": "boolean"
     },
     "notifications": {
       "description": "Notification settings",


### PR DESCRIPTION
Aby sme mohli renderovať zrušené eventy iným spôsobom, podobne ako `volatile`.

Viď kockatykalendar/frontend#69.