### PR TITLE
Change contestants schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ používame [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ### Added
 - Pridaný flag `cancelled` na označenie zrušených udalostí.
 
+### Changed
+- Pri eventoch vyžadujeme `contestants.min` aj `contestants.max`, pričom obe môžu byť `null`. Issue #26.
+
 ## 0.0.3 - 2020-11-03
 ### Added
 - Pridané `color` na zmenu farby udalosti v kalendári.

--- a/build.py
+++ b/build.py
@@ -45,7 +45,7 @@ for directory in os.walk(os.path.join(ROOT, "data")):
         with open(path) as f:
             event_data = yaml.safe_load(f)
             try:
-                validate_event(event_data)
+                event_data = validate_event(event_data)
                 if not args.dry:
                     event_date = datetime.strptime(
                         event_data["date"]["start"], "%Y-%m-%d"

--- a/data/2020_21/03_november/mo-z5.yml
+++ b/data/2020_21/03_november/mo-z5.yml
@@ -6,6 +6,7 @@ date:
   start: "2020-11-16"
 contestants:
   min: zs5
+  max: zs5
 places:
   - online
 organizers:

--- a/data/2020_21/03_november/mo-z9.yml
+++ b/data/2020_21/03_november/mo-z9.yml
@@ -6,6 +6,7 @@ date:
   start: "2020-11-16"
 contestants:
   min: zs9
+  max: zs9
 places:
   - online
 organizers:

--- a/data/2020_21/04_december/advent.yml
+++ b/data/2020_21/04_december/advent.yml
@@ -7,6 +7,7 @@ date:
   end: "2020-12-24"
 contestants:
   min: ss1
+  max: ss1
 info: "Každý adventný deň o 8:00 zverejníme jednu matematickú úlohu. Zapojiť sa môže ktokoľvek. Pri odovzdávaní môžte povedať či úloha bola pre vás príliš ľahká, ťažká alebo akurát. Ak bude veľa odpovedí jedného typu upravíme obťažnosť nasledujúcich dní."
 places:
   - online

--- a/data/2020_21/04_december/advent.yml
+++ b/data/2020_21/04_december/advent.yml
@@ -7,7 +7,7 @@ date:
   end: "2020-12-24"
 contestants:
   min: ss1
-  max: ss1
+  max: null
 info: "Každý adventný deň o 8:00 zverejníme jednu matematickú úlohu. Zapojiť sa môže ktokoľvek. Pri odovzdávaní môžte povedať či úloha bola pre vás príliš ľahká, ťažká alebo akurát. Ak bude veľa odpovedí jedného typu upravíme obťažnosť nasledujúcich dní."
 places:
   - online

--- a/data/2020_21/04_december/mo_z5.yml
+++ b/data/2020_21/04_december/mo_z5.yml
@@ -6,6 +6,7 @@ date:
   start: "2020-12-14"
 contestants:
   min: zs5
+  max: zs5
 places:
   - online
 organizers:

--- a/data/2020_21/04_december/mo_z9.yml
+++ b/data/2020_21/04_december/mo_z9.yml
@@ -6,6 +6,7 @@ date:
   start: "2020-12-14"
 contestants:
   min: zs9
+  max: zs9
 places:
   - online
 organizers:

--- a/data/2020_21/05_january/mo_c.yml
+++ b/data/2020_21/05_january/mo_c.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-01-18"
 contestants:
   min: ss1
+  max: ss1
 places:
   - online
 organizers:

--- a/data/2020_21/05_january/mo_c_skolske.yml
+++ b/data/2020_21/05_january/mo_c_skolske.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-01-26"
 contestants:
   min: ss1
+  max: ss1
 places:
   - online
 organizers:

--- a/data/2020_21/05_january/mo_z5.yml
+++ b/data/2020_21/05_january/mo_z5.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-01-27"
 contestants:
   min: zs5
+  max: zs5
 places:
   - online
 organizers:

--- a/data/2020_21/05_january/mo_z9.yml
+++ b/data/2020_21/05_january/mo_z9.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-01-27"
 contestants:
   min: zs9
+  max: zs9
 places:
   - online
 organizers:

--- a/data/2020_21/07_march/mo_c.yml
+++ b/data/2020_21/07_march/mo_c.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-03-30"
 contestants:
   min: ss1
+  max: ss1
 places:
   - online
 organizers:

--- a/data/2020_21/07_march/mo_z9.yml
+++ b/data/2020_21/07_march/mo_z9.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-03-16"
 contestants:
   min: zs9
+  max: zs9
 places:
   - online
 organizers:

--- a/data/2020_21/08_april/fo_d.yml
+++ b/data/2020_21/08_april/fo_d.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-04-23"
 contestants:
   min: ss1
+  max: ss1
 places:
   - online
 organizers:

--- a/data/2020_21/09_may/fo_d.yml
+++ b/data/2020_21/09_may/fo_d.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-05-12"
 contestants:
   min: ss1
+  max: ss1
 places:
   - online
 organizers:

--- a/data/2020_21/09_may/testovanie_5.yml
+++ b/data/2020_21/09_may/testovanie_5.yml
@@ -6,6 +6,7 @@ date:
   start: "2021-05-19"
 contestants:
   min: zs5
+  max: zs5
 places:
   - online
 organizers:

--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -95,12 +95,14 @@
       ]
     },
     "volatile": {
-      "description": "If true event may not take place",
-      "type": "boolean"
+      "description": "If true, the event may not take place due to COVID-19 restrictions",
+      "type": "boolean",
+      "default": false
     },
     "cancelled": {
       "description": "If true, the event was cancelled",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "notifications": {
       "description": "Notification settings",

--- a/schemas/event.schema.json
+++ b/schemas/event.schema.json
@@ -69,17 +69,17 @@
       "type": "object",
       "properties": {
         "min": {
-          "description": "Min class to attend",
-          "type": "string",
+          "description": "Minimal required attended class",
+          "type": ["string", "null"],
           "pattern": "^(zs[1-9]|ss[1-4])$"
         },
         "max": {
-          "description": "Max class to attend",
-          "type": "string",
+          "description": "Maximal allowed attended class",
+          "type": ["string", "null"],
           "pattern": "^(zs[1-9]|ss[1-4])$"
         }
       },
-      "required": ["min"]
+      "required": ["min", "max"]
     },
     "info": {
       "description": "Short description of event",


### PR DESCRIPTION
Odteraz je min aj max povinný, avšak pre open súťaže môžu byť `null`.

Closes #26.

Pls review @Zajozor a @krtko1 by mohol skontrolovať akcie, ktoré som zmenil. Pomenil som to síce podľa aktuálnej implementácie, ktorú používa frontend, ale z toho vyplýva, že napr. `advent` je len pre `ss1`?

// Ak sa changelog mergne skôr, treba tieto zmeny dopísať do neho.