### PR TITLE
pmat-2021-22-zima: cancel events

### DIFF
--- a/data/2021_22/seminare/pmat/KV1jar.yaml
+++ b/data/2021_22/seminare/pmat/KV1jar.yaml
@@ -9,6 +9,7 @@ date:
 contestants:
   min: zs5
   max: zs9
+volatile: true
 places:
   - TBD
 organizers:

--- a/data/2021_22/seminare/pmat/KV1jesen.yaml
+++ b/data/2021_22/seminare/pmat/KV1jesen.yaml
@@ -9,6 +9,7 @@ date:
 contestants:
   min: zs5
   max: zs9
+volatile: true
 cancelled: true
 places:
   - TBD

--- a/data/2021_22/seminare/pmat/KV2jar.yaml
+++ b/data/2021_22/seminare/pmat/KV2jar.yaml
@@ -9,6 +9,7 @@ date:
 contestants:
   min: zs5
   max: zs9
+volatile: true
 places:
   - TBD
 organizers:

--- a/data/2021_22/seminare/pmat/KV2jesen.yaml
+++ b/data/2021_22/seminare/pmat/KV2jesen.yaml
@@ -11,6 +11,8 @@ contestants:
   max: zs9
 places:
   - TBD
+volatile: true
+cancelled: true
 organizers:
   - p-mat
 link: https://www.p-mat.sk/aktivity/kockaty/

--- a/data/2021_22/seminare/pmat/ZsustredeniePF.yaml
+++ b/data/2021_22/seminare/pmat/ZsustredeniePF.yaml
@@ -10,6 +10,8 @@ contestants:
   max: zs9
 places:
   - TBD
+volatile: true
+cancelled: true
 organizers:
   - p-mat
 link: https://pikofyz.sk/

--- a/data/2021_22/seminare/pmat/ZsustredeniePMM.yaml
+++ b/data/2021_22/seminare/pmat/ZsustredeniePMM.yaml
@@ -10,6 +10,8 @@ contestants:
   max: zs6
 places:
   - TBD
+volatile: true
+cancelled: true
 organizers:
   - p-mat
 link: https://pikomat.sk/

--- a/data/2021_22/seminare/pmat/ZsustredeniePMS.yaml
+++ b/data/2021_22/seminare/pmat/ZsustredeniePMS.yaml
@@ -10,6 +10,8 @@ contestants:
   max: zs9
 places:
   - TBD
+volatile: true
+cancelled: true
 organizers:
   - p-mat
 link: https://pikomat.sk/

--- a/data/2021_22/sutaze/attomat_dec.yml
+++ b/data/2021_22/sutaze/attomat_dec.yml
@@ -1,0 +1,14 @@
+name: ATTOMAT
+type: sutaz
+sciences:
+  - mat
+date:
+  start: "2021-12-9"
+contestants:
+  min: zs5
+  max: zs9
+places:
+  - online
+organizers:
+  - p-mat
+link: https://www.p-mat.sk/aktivity/attomat/


### PR DESCRIPTION
Ešte by to chcelo pridať tie pmat rodičká ale neviem čo je to poriadne zač a potom asi aj tie jednodnové náhrady sústrediek. Ale tiež by sme mohli počkať aspoň kým začne prihlasovanie vedúcich na to